### PR TITLE
Fix bugs and reposition the 'receiveTaskResource' function.

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,7 @@
+package main
+
+import "net/http"
+
+func ReceiveTaskResource(w http.ResponseWriter, r *http.Request) {
+	
+}

--- a/file.go
+++ b/file.go
@@ -1,7 +1,0 @@
-package main
-
-import "net/http"
-
-func ReceiveTaskResource(w http.ResponseWriter, r *http.Request) {
-	
-}

--- a/host.go
+++ b/host.go
@@ -34,7 +34,7 @@ func newHost(w *gotron.BrowserWindow) *Host {
 func (h *Host) run() {
 	listener := h.init()
 	h.gotronMessageHandler()
-	h.httpMessageHandler(listener)
+	go h.httpMessageHandler(listener)
 }
 
 func (h *Host) init() (listener net.Listener) {
@@ -72,8 +72,13 @@ func (h *Host) gotronMessageHandler() {
 }
 
 func (h *Host) httpMessageHandler(listenser net.Listener) {
+	// handlers for application
 	http.HandleFunc("/"+h.token, h.receiveConnectionRequest)
 	http.HandleFunc("/status", h.receiveWorkerStatus)
+
+	// handlers for blender
+	http.HandleFunc("/running/check", h.receiveRunningCheck)
+	http.HandleFunc("/task/resource", ReceiveTaskResource)
 
 	http.Serve(listenser, nil)
 }
@@ -117,4 +122,10 @@ func (h *Host) receiveWorkerStatus(w http.ResponseWriter, r *http.Request) {
 
 	// Update worker status at host's window. ( Method : "Update" )
 	h.send("window.device.status", &worker)
+}
+
+func (h *Host) receiveRunningCheck(w http.ResponseWriter, r *http.Request) {
+	log.Fatal("Blender Add-On : checking host running...")
+	w.WriteHeader(http.StatusOK) // return status code 200
+	// return 404 when host is not running
 }

--- a/host.go
+++ b/host.go
@@ -18,6 +18,9 @@ type Host struct {
 	index      chan int
 	register   chan *Worker
 	unregister chan int
+
+	filePath   chan string
+	tiles      []Tile
 }
 
 func newHost(w *gotron.BrowserWindow) *Host {
@@ -26,6 +29,7 @@ func newHost(w *gotron.BrowserWindow) *Host {
 
 		workers:    make(map[int]*Worker),
 		index:      make(chan int),
+		filePath:   make(chan string),
 		register:   make(chan *Worker),
 		unregister: make(chan int),
 	}
@@ -78,7 +82,7 @@ func (h *Host) httpMessageHandler(listener net.Listener) {
 
 	// handlers for blender
 	http.HandleFunc("/running/check", h.receiveRunningCheck)
-	http.HandleFunc("/task/resource", ReceiveTaskResource)
+	http.HandleFunc("/task/resource", h.ReceiveTaskResource)
 
 	http.Serve(listener, nil)
 }
@@ -137,6 +141,9 @@ func (h *Host) receiveTilesInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, tile := range tiles {
-		tile.prettyPrint()
+		tile.prettyPrint() // printing tiles information
 	}
+
+	h.tiles = tiles
+	h.DoRender() // tiles : tile information, path : blender file path
 }

--- a/host.go
+++ b/host.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"github.com/Equanox/gotron"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 type Host struct {
@@ -122,7 +128,7 @@ func (h *Host) receiveWorkerStatus(w http.ResponseWriter, r *http.Request) {
 		log.Fatal("func : receiveWorkerStatus\n", err)
 	}
 
-	h.workers[worker.Id] = &worker
+	h.workers[worker.Id] = &worker // TODO need to create a function for update worker.
 
 	// Update worker status at host's window. ( Method : "Update" )
 	h.send("window.device.status", &worker)
@@ -146,4 +152,40 @@ func (h *Host) receiveTilesInfo(w http.ResponseWriter, r *http.Request) {
 
 	h.tiles = tiles
 	h.DoRender() // tiles : tile information, path : blender file path
+}
+
+func (h *Host) ReceiveTaskResource(w http.ResponseWriter, r *http.Request) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+
+	fmt.Print("blen : ", string(reqBody[0:4]))
+	if blen := string(reqBody[:4]); strings.Compare(blen, "blen") != 0 {
+		log.Fatal("func : ReceiveTaskResource\n", "This is not a task resource request.")
+	}
+	buffer := bytes.NewBuffer(reqBody[4:8])
+	fileSize, err := binary.ReadVarint(buffer)
+	fmt.Print("size : ", fileSize)
+
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", "This is not a number.")
+	}
+
+	//if fileSize != len(reqBody[8:]) {
+	//	log.Fatal("func : ReceiveTaskResource\n", "An error occurred while receiving the file.")
+	//}
+
+	dir := filepath.Join(os.TempDir(), "main.blend")
+	err = ioutil.WriteFile(dir, reqBody[8:], 0644)
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", "File Writing Error.")
+	}
+	fmt.Print("dir:", dir)
+
+	h.filePath <- dir
 }

--- a/render.go
+++ b/render.go
@@ -1,53 +1,5 @@
 package main
 
-import (
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-)
-
-func (h *Host) ReceiveTaskResource(w http.ResponseWriter, r *http.Request) {
-	reqBody, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Fatal("func : ReceiveTaskResource\n", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
-
-	fmt.Print("blen : ", string(reqBody[0:4]))
-	if blen := string(reqBody[:4]); strings.Compare(blen, "blen") != 0 {
-		log.Fatal("func : ReceiveTaskResource\n", "This is not a task resource request.")
-	}
-	buffer := bytes.NewBuffer(reqBody[4:8])
-	fileSize, err := binary.ReadVarint(buffer)
-	fmt.Print("size : ", fileSize)
-
-	if err != nil {
-		log.Fatal("func : ReceiveTaskResource\n", "This is not a number.")
-	}
-
-	//if fileSize != len(reqBody[8:]) {
-	//	log.Fatal("func : ReceiveTaskResource\n", "An error occurred while receiving the file.")
-	//}
-
-	dir := filepath.Join(os.TempDir(), "main.blend")
-	err = ioutil.WriteFile(dir, reqBody[8:], 0644)
-	if err != nil {
-		log.Fatal("func : ReceiveTaskResource\n", "File Writing Error.")
-	}
-	fmt.Print("dir:", dir)
-
-	h.filePath <- dir
-}
-
 func (h *Host) DoRender() {
 	path := <- h.filePath // blend file path
 

--- a/render.go
+++ b/render.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func (h *Host) ReceiveTaskResource(w http.ResponseWriter, r *http.Request) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+
+	if blen := string(reqBody[:1]); strings.Compare(blen, "blen") != 0 {
+		log.Fatal("func : ReceiveTaskResource\n", "This is not a task resource request.")
+	}
+
+	fileSize, err := strconv.Atoi(string(reqBody[1:2]))
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", "This is not a number.")
+	}
+
+	if fileSize != len(reqBody[2:]) {
+		log.Fatal("func : ReceiveTaskResource\n", "An error occurred while receiving the file.")
+	}
+
+	dir := os.TempDir() + "/main.blend"
+	err = ioutil.WriteFile(dir, reqBody[2:], 0644)
+	if err != nil {
+		log.Fatal("func : ReceiveTaskResource\n", "File Writing Error.")
+	}
+
+	h.filePath <- dir
+}
+
+func (h *Host) DoRender() {
+	path := <- h.filePath // blend file path
+
+	var remaining []Tile
+	for {
+		// remaining tiles -> should be render.
+		remaining = filter(h.tiles, func(v Tile) bool {
+			return !v.Active
+		})
+
+		// When there are no tiles left, rendering complete
+		if len(remaining) == 0 {
+			break
+		}
+
+		// for all remaining tiles
+		for _, tile := range remaining {
+			tile.Active = true
+			tile.Dispatch(h, path)
+		}
+	}
+}
+
+func filter(vs []Tile, f func(Tile) bool) []Tile {
+	vsf := make([]Tile, 0)
+	for _, v := range vs {
+		if f(v) {
+			vsf = append(vsf, v)
+		}
+	}
+	return vsf
+}

--- a/tile.go
+++ b/tile.go
@@ -1,6 +1,14 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strconv"
+)
 
 type Tile struct {
 	Index int `json:"index"`
@@ -9,9 +17,68 @@ type Tile struct {
 	Xmax  int `json:"xmax"`
 	Ymax  int `json:"ymax"`
 	Frame int `json:"fram"`
+
+	// In JSON parsing, the following parameters are ignored.
+	Active  bool `json:"-"`
+	Success bool `json:"-"`
 }
 
-func (t *Tile) prettyPrint(){
+func (t *Tile) prettyPrint() {
 	fmt.Printf("Tile: { \"index\" : %d, \"xmin\" : %d, \"ymin\" : %d, \"xmax\" : %d, \"ymax\" : %d, \"frame\" : %d}\n", t.Index, t.Xmin, t.Ymin, t.Xmax, t.Ymax, t.Frame)
 }
 
+func (t *Tile) Dispatch(h *Host, path string) {
+	for _, worker := range h.workers {
+		if worker.Status == "" {
+			r, w := io.Pipe()
+			m := multipart.NewWriter(w)
+
+			go func() {
+				defer w.Close()
+				defer m.Close()
+
+				part, err := m.CreateFormFile("blend-file", path)
+				if err != nil {
+					log.Fatal("func : Dispatch\n", err)
+				}
+
+				file, err := os.Open(path)
+				if err != nil {
+					log.Fatal("func : Dispatch\n", err)
+				}
+				defer file.Close()
+
+				if _, err := io.Copy(part, file); err != nil {
+					log.Fatal("func : Dispatch\n", err)
+				}
+			}()
+
+			req, err := http.NewRequest("POST", worker.Address.generateHostAddress("/render/resource"), r)
+			if err != nil {
+				log.Fatal("func : Dispatch\n", err)
+			}
+
+			req.Header.Add("Content-Type", m.FormDataContentType())
+			req.Header.Add("index", strconv.Itoa(t.Index))
+			req.Header.Add("xmin", strconv.Itoa(t.Xmin))
+			req.Header.Add("ymin", strconv.Itoa(t.Ymin))
+			req.Header.Add("xmax", strconv.Itoa(t.Xmax))
+			req.Header.Add("ymax", strconv.Itoa(t.Ymax))
+			req.Header.Add("fram", strconv.Itoa(t.Frame))
+
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				log.Fatal("func : Dispatch\n", err)
+			}
+
+			resp.Body.Close()
+			worker.Status = "running"
+			break
+		}
+	}
+}
+
+func (t *Tile) makePythonFile() string {
+
+}

--- a/tile.go
+++ b/tile.go
@@ -7,16 +7,15 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"strconv"
 )
 
 type Tile struct {
-	Index int `json:"index"`
-	Xmin  int `json:"xmin"`
-	Ymin  int `json:"ymin"`
-	Xmax  int `json:"xmax"`
-	Ymax  int `json:"ymax"`
-	Frame int `json:"fram"`
+	Index string `json:"index"`
+	Xmin  string `json:"xmin"`
+	Ymin  string `json:"ymin"`
+	Xmax  string `json:"xmax"`
+	Ymax  string `json:"ymax"`
+	Frame string `json:"fram"`
 
 	// In JSON parsing, the following parameters are ignored.
 	Active  bool `json:"-"`
@@ -59,12 +58,12 @@ func (t *Tile) Dispatch(h *Host, path string) {
 			}
 
 			req.Header.Add("Content-Type", m.FormDataContentType())
-			req.Header.Add("index", strconv.Itoa(t.Index))
-			req.Header.Add("xmin", strconv.Itoa(t.Xmin))
-			req.Header.Add("ymin", strconv.Itoa(t.Ymin))
-			req.Header.Add("xmax", strconv.Itoa(t.Xmax))
-			req.Header.Add("ymax", strconv.Itoa(t.Ymax))
-			req.Header.Add("fram", strconv.Itoa(t.Frame))
+			req.Header.Add("index", t.Index)
+			req.Header.Add("xmin", t.Xmin)
+			req.Header.Add("ymin", t.Ymin)
+			req.Header.Add("xmax", t.Xmax)
+			req.Header.Add("ymax", t.Ymax)
+			req.Header.Add("fram", t.Frame)
 
 			client := &http.Client{}
 			resp, err := client.Do(req)
@@ -77,8 +76,4 @@ func (t *Tile) Dispatch(h *Host, path string) {
 			break
 		}
 	}
-}
-
-func (t *Tile) makePythonFile() string {
-
 }

--- a/tile.go
+++ b/tile.go
@@ -27,7 +27,10 @@ func (t *Tile) prettyPrint() {
 }
 
 func (t *Tile) Dispatch(h *Host, path string) {
-	for _, worker := range h.workers {
+	var worker *Worker
+
+	for key := range h.workers {
+		worker = h.workers[key]
 		if worker.Status == "" {
 			r, w := io.Pipe()
 			m := multipart.NewWriter(w)


### PR DESCRIPTION
- Worker에서 Task를 전송받았을 때 `renderTileWithBlender` 함수가 여러번 수행되었던 것을 수정하였습니다.
> 원인 : Host에 있는 Worker의 Status를 받는 함수에서 계속해서 Worker의 Status를 빈 문자열로 초기화 시켜주고 있었습니다.

- `receiveTaskResource` 함수의 위치를 변경하였습니다. 
> Host와 관련이 가장 많은 것 같아 `host.go`로 위치를 옴겨주었습니다. 